### PR TITLE
Accept partial DMX frames

### DIFF
--- a/DMXlib.c
+++ b/DMXlib.c
@@ -102,7 +102,7 @@ void DMXReceive(void)
     	        }
                 while (!PIR1bits.RCIF) ;        //Wait until a byte is correctly received
     	        DMXBuffer[DMXBytesReceived++] = RCREG;
-        	    if (DMXBytesReceived < DMX_BUFFER_SIZE) {
+        	    if (DMXBytesReceived < DMXEndChannel) {
                     DMXState = DMXWaitForData;
                     break;
                 } else {

--- a/DMXlib.c
+++ b/DMXlib.c
@@ -78,6 +78,7 @@ void DMXReceive(void)
                 while (!PIR1bits.RCIF) ;        //Wait until a byte has been received
                 if (RCSTAbits.FERR) {
                     DMXState = DMXGotBreak;
+                    PIR1bits.RCIF = 0;          //Reset the received flag
 			        break;
 		        } else {
 			        DMXInputBuffer = RCREG;     //Read the Receive buffer
@@ -93,18 +94,17 @@ void DMXReceive(void)
                 }
             case DMXWaitForData:
                 if (RCSTAbits.FERR) {	        //If a new framing error is detected (error or short frame)
-                    DMXState = DMXWaitBreak;	// the rest of the frame is ignored and a new synchronization
-        	        break;                      //is attempted
+                    DMXState = DMXDone;	        // the rest of the frame is ignored and the function exits
+        	        break;
     	        }
-                if (PIR1bits.RCIF) {	        //Wait until a byte is correctly received
-    	            DMXBuffer[DMXBytesReceived++] = RCREG;
-        	        if (DMXBytesReceived < DMX_BUFFER_SIZE) {
-                        DMXState = DMXWaitForData;
-                        break;
-                    } else {
-                        DMXState = DMXDone;
-                        break;
-                    }
+                while (!PIR1bits.RCIF) ;        //Wait until a byte is correctly received
+    	        DMXBuffer[DMXBytesReceived++] = RCREG;
+        	    if (DMXBytesReceived < DMX_BUFFER_SIZE) {
+                    DMXState = DMXWaitForData;
+                    break;
+                } else {
+                    DMXState = DMXDone;
+                    break;
                 }
                 break;
             case DMXDone:

--- a/DMXlib.c
+++ b/DMXlib.c
@@ -33,6 +33,7 @@ enum {
 } DMXState;
 
 // Variables
+int DMXCurrentChannel;
 int DMXBytesReceived; //16-bit counter
 char DMXInputBuffer; //used to read RCREG to clear error conditions
 
@@ -58,6 +59,7 @@ void DMXSetup(void)
 void DMXReceive(void)
 {
     DMXState = DMXWaitBreak;
+    DMXCurrentChannel = 0;
     while (DMXState != DMXDone) {
         switch (DMXState) {
             case DMXWaitBreak:

--- a/DMXlib.h
+++ b/DMXlib.h
@@ -30,7 +30,8 @@
  
  // Variables
 char DMXBuffer[DMX_BUFFER_SIZE];
-int DMXStartChannel = 0;
+int DMXStartChannel = 1;
+int DMXEndChannel = 512;
 
 // Functions
 void DMXSetup(void);

--- a/masterChipSendSignal.c
+++ b/masterChipSendSignal.c
@@ -141,6 +141,7 @@ void main(void)
     Setup();
     DMXSetup();
     DMXStartChannel = ReadDMXStartChannel();
+    DMXEndChannel = DMXStartChannel - 1 + (NUMBER_OF_SLAVES * BYTES_PER_SLAVE);
     while(1)
     {
 		DMXReceive();


### PR DESCRIPTION
If we get a partial (non-512-byte) DMX frame, we recover.
Thanks @aterlumen for the commits!

I think that this will be a long chain; we'll have to decide what is an error for an incomplete frame and when we are just correctly receiving a partial frame.

Fixes #28, resets RCIF when it is not cleared automatically.
